### PR TITLE
(chore) Bump peer dependencies to Angular 15 compatible versions

### DIFF
--- a/projects/ngx-file-uploader/package.json
+++ b/projects/ngx-file-uploader/package.json
@@ -2,15 +2,15 @@
   "name": "@openmrs/ngx-file-uploader",
   "version": "0.0.15",
   "peerDependencies": {
-    "@angular/animations": "^14.2.7",
-    "@angular/cdk": "^14.2.7",
-    "@angular/common": "^14.2.7",
-    "@angular/compiler": "^14.2.7",
-    "@angular/core": "^14.2.7",
-    "@angular/forms": "^14.2.7",
-    "@angular/material": "^14.2.7",
-    "@angular/platform-browser": "^14.2.7",
-    "@angular/platform-browser-dynamic": "^14.2.7",
-    "@angular/router": "^14.2.7"
+    "@angular/animations": "^15.2.10",
+    "@angular/cdk": "15.2.9",
+    "@angular/common": "^15.2.10",
+    "@angular/compiler": "^15.2.10",
+    "@angular/core": "^15.2.10",
+    "@angular/forms": "^15.2.10",
+    "@angular/material": "15.2.9",
+    "@angular/platform-browser": "^15.2.10",
+    "@angular/platform-browser-dynamic": "^15.2.10",
+    "@angular/router": "^15.2.10"
   }
 }


### PR DESCRIPTION
Just bumps peer dependencies for this library to their Angular v15 compatible versions, which ought to have happened in #1.